### PR TITLE
3Dモデルのロードを並列化する

### DIFF
--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
@@ -1,0 +1,217 @@
+﻿using UnityEngine;
+using System.Collections;
+using Cysharp.Threading.Tasks;
+using System.Threading;
+using System.Collections.Generic;
+using System;
+
+
+/// <summary>
+/// モデルロードをスロットリングするクラス
+/// 汎用の作りをしているので、実はモデルロード以外にも利用可能。
+/// </summary>
+public class ModelLoadScheduler : MonoBehaviour
+{
+    public enum TaskState
+    {
+        Waiting,
+        Running,
+        Success,
+        Failed,
+        Cancelled,
+    }
+
+    /// <summary>
+    /// 実行対象のタスク
+    /// </summary>
+    public interface Task
+    {
+        UniTask<(bool result, object artifact)> Do(CancellationToken token);
+    }
+
+    /// <summary>
+    /// タスクのメタデータを保持するCarrier
+    /// </summary>
+    public class TaskCarrier : IDisposable
+    {
+        public string Name { get; }
+
+        // priorityの高い順に実行される。後から変更も可能。
+        // 現時点で実行順の調整処理は未実装 (2024/9/16)
+        public float Priority { get; set; }
+        public CancellationToken CancellationToken { get; }
+
+        // ModelLoadSchedulerからもキャンセルしたいので、元のCancellationTokenとリンクしたCancellationTokenSourceを作成して保持する。
+        public CancellationTokenSource LinkedCancellationTokenSource { get; private set; }
+
+        public TaskState State { get; set; }
+        public Exception Exception { get; set; }
+
+        public Task Task { get; }
+
+        public TaskCarrier(string name, CancellationToken token, Task task)
+        {
+            Name = name;
+            CancellationToken = token;
+            State = TaskState.Waiting;
+            Task = task;
+        }
+
+        public void MakeLinkedCancellationTokenSource()
+        {
+            if (LinkedCancellationTokenSource != null)
+            {
+                Debug.LogError("LinkedCancellationTokenSource already initialized.");
+                return;
+            }
+            LinkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+        }
+
+        public void CancelTask()
+        {
+            LinkedCancellationTokenSource?.Cancel();
+        }
+
+        public void Dispose()
+        {
+            if (LinkedCancellationTokenSource != null)
+            {
+                ((IDisposable)LinkedCancellationTokenSource).Dispose();
+            }
+        }
+    }
+
+    private static ModelLoadScheduler instance;
+    public static ModelLoadScheduler Instance => instance;
+
+    /// <summary>
+    /// 待機中のタスクリスト
+    /// </summary>
+    private List<TaskCarrier> waitingTasks = new List<TaskCarrier>();
+
+    /// <summary>
+    /// 実行中のタスクリスト
+    /// </summary>
+    private List<TaskCarrier> runningTasks = new List<TaskCarrier>();
+
+    const int concurrencyLimit = 8;
+
+    public int RemainingTasksCount => waitingTasks.Count + runningTasks.Count;
+
+    public static void CreateGameObject()
+    {
+        var go = new GameObject("ModelLoadScheduler");
+        go.AddComponent<ModelLoadScheduler>();
+    }
+
+    private void Awake()
+    {
+        instance = this;
+        DontDestroyOnLoad(this.gameObject);
+    }
+
+    void Start()
+    {
+    }
+
+    void Update()
+    {
+        RunNextTasks();
+    }
+
+    private void OnDestroy()
+    {
+        StopAllTasks();
+    }
+
+    /// <summary>
+    /// タスクをキューに追加する
+    /// </summary>
+    /// <param name="name"></param>
+    /// <param name="token"></param>
+    /// <param name="priority"></param>
+    /// <param name="task"></param>
+    /// <returns></returns>
+    public TaskCarrier AddTask(string name, CancellationToken token, float priority, ModelLoadScheduler.Task task)
+    {
+        var carrier = new TaskCarrier(name, token, task);
+        carrier.Priority = priority;
+        waitingTasks.Add(carrier);
+        return carrier;
+    }
+
+    /// <summary>
+    /// スロットの空きがあり、残りタスクがあればタスクを実行する
+    /// </summary>
+    void RunNextTasks()
+    {
+        while (runningTasks.Count < concurrencyLimit && waitingTasks.Count > 0)
+        {
+            var carrier = waitingTasks[0];
+            waitingTasks.RemoveAt(0);
+            if (carrier.CancellationToken.IsCancellationRequested)
+            {
+                Debug.Log($"Didn't run the task {carrier.Name} because it is already cancelled.");
+                return;
+            }
+            RunTask(carrier);
+        }
+    }
+
+    /// <summary>
+    /// 該当タスクを実行する
+    /// 実行中、TaskCarrierのStateはRunningになり、runningTasks に入る。
+    /// </summary>
+    /// <param name="task"></param>
+    void RunTask(TaskCarrier carrier)
+    {
+        UniTask.Void(async () =>
+        {
+            try
+            {
+                runningTasks.Add(carrier);
+                carrier.MakeLinkedCancellationTokenSource();
+                carrier.State = TaskState.Running;
+                Debug.Log($"++++ start task {carrier.Name} concurrency: {runningTasks.Count}");
+                var result = await carrier.Task.Do(carrier.CancellationToken);
+                if (result.result)
+                {
+                    carrier.State = TaskState.Success;
+                }
+                else
+                {
+                    carrier.State = TaskState.Failed;
+                    carrier.Exception = new Exception("the task returned failure.");
+                }
+            }
+            catch (OperationCanceledException e)
+            {
+                carrier.State = TaskState.Cancelled;
+            }
+            catch (Exception e)
+            {
+                carrier.State = TaskState.Failed;
+                carrier.Exception = e;
+            }
+            finally
+            {
+                runningTasks.Remove(carrier);
+                Debug.Log($"---- end task {carrier.Name} state: {carrier.State} concurrency: {runningTasks.Count}");
+            }
+        });
+    }
+
+    /// <summary>
+    /// キューイングされたすべてのタスクを止めて、タスクキューをクリアする。
+    /// </summary>
+    public void StopAllTasks()
+    {
+        waitingTasks.Clear();
+        foreach (var carrier in runningTasks)
+        {
+            carrier.CancelTask();
+            carrier.Dispose();
+        }
+        runningTasks.Clear();
+    }
+}

--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs.meta
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c654a012ef14f4ea2959c9b20f267d1c
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
+++ b/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
@@ -76,45 +76,53 @@ namespace GeoTile
 
             if (GUILayout.Button("Load GLTF " + (gltfFound ? "":"(not available)") + (alreadyLoaded ? "(already loaded)" : "" )))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModel(), this);
+                LoadModelRecursive(Target, 1);
             }
 
             if (GUILayout.Button("Load GLTF Under This (2 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 2), this);
+                LoadModelRecursive(Target, 2);
             }
             if (GUILayout.Button("Load GLTF Under This (3 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 3), this);
+                LoadModelRecursive(Target, 3);
             }
             if (GUILayout.Button("Load GLTF Under This (4 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 4), this);
+                LoadModelRecursive(Target, 4);
             }
             if (GUILayout.Button("Load GLTF Under This (5 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 5), this);
+                LoadModelRecursive(Target, 5);
             }
             if (GUILayout.Button("Load GLTF Under This (6 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 6), this);
+                LoadModelRecursive(Target, 6);
             }
             if (GUILayout.Button("Load GLTF Under This (7 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 7), this);
+                LoadModelRecursive(Target, 7);
             }
             if (GUILayout.Button("Load GLTF Under This (8 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 8), this);
+                LoadModelRecursive(Target, 8);
             }
             if (GUILayout.Button("Load GLTF Under This (9 Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 9), this);
+                LoadModelRecursive(Target, 9);
             }
             if (GUILayout.Button("Load GLTF Under This (Unlimited(100) Level)"))
             {
-                EditorCoroutineUtility.StartCoroutine(Target.LoadModelRecursive(0, 100), this);
+                LoadModelRecursive(Target, 100);
             }
+        }
+
+        void LoadModelRecursive(TileSetNodeComponent node, int depthLimit)
+        {
+            EditorCoroutineUtility.StartCoroutine(UniTask.ToCoroutine(async () =>
+            {
+                await Target.LoadModelRecursive(0, depthLimit, Target.GetCancellationTokenOnDestroy());
+            }), this);
         }
     }
 }

--- a/Assets/GeoTileLoader/Samples/Scripts/SampleUI.cs
+++ b/Assets/GeoTileLoader/Samples/Scripts/SampleUI.cs
@@ -48,8 +48,19 @@ namespace GeoTile.Samples
         void Update()
         {
             loadHierarchyButton.interactable = !isBusy;
-            load3DModelButton.interactable = !isBusy;
-            stopButton.interactable = isBusy;
+
+            // ModelLoadScheduler が動いている間はロード中と考える。
+            load3DModelButton.interactable = !isBusy && !IsLoadTasksRemain();
+            stopButton.interactable = isBusy || IsLoadTasksRemain();
+        }
+
+        bool IsLoadTasksRemain()
+        {
+            if (!ModelLoadScheduler.Instance)
+            {
+                return false;
+            }
+            return ModelLoadScheduler.Instance.RemainingTasksCount > 0;
         }
 
         /// <summary>
@@ -64,6 +75,7 @@ namespace GeoTile.Samples
             {
                 try
                 {
+                    ModelLoadScheduler.Instance?.StopAllTasks();
                     cts = new CancellationTokenSource();
                     isBusy = true;
                     messageText.text = "Loading Hierarchy...";
@@ -140,7 +152,7 @@ namespace GeoTile.Samples
             cts?.Cancel();
             cts?.Dispose();
             cts = null;
+            ModelLoadScheduler.Instance?.StopAllTasks();
         }
-
     }
 }

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -135,7 +135,7 @@ namespace GeoTile
                 return;
             }
 
-            await node.LoadModel();
+            await node.LoadModel(token);
             await UniTask.Delay(20, cancellationToken: token);
         }
 


### PR DESCRIPTION
Fixes #4 

## 概要

3Dモデルのロードを高速化するが、ネットアクセスの並列度はコントロールしたい。
ModelLoadSchedulerクラスを作成し、タスクを並列に実行できるようにした。
ModelLoadSchedulerクラスは汎用の設計になっていて、ModelLoadScheduler.Taskインタフェースを継承したタスクを実行できる。
