### PR TITLE
キャンセル時に地図メッシュの断片が残る問題を修正

### DIFF
--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
@@ -39,7 +39,10 @@ public class ModelLoadScheduler : MonoBehaviour
         // priorityの高い順に実行される。後から変更も可能。
         // 現時点で実行順の調整処理は未実装 (2024/9/16)
         public float Priority { get; set; }
-        public CancellationToken CancellationToken { get; }
+        
+        private CancellationToken sourceCancellationToken;
+
+        public CancellationToken CancellationToken { get; private set; }
 
         // ModelLoadSchedulerからもキャンセルしたいので、元のCancellationTokenとリンクしたCancellationTokenSourceを作成して保持する。
         public CancellationTokenSource LinkedCancellationTokenSource { get; private set; }
@@ -52,9 +55,9 @@ public class ModelLoadScheduler : MonoBehaviour
         public TaskCarrier(string name, CancellationToken token, Task task)
         {
             Name = name;
-            CancellationToken = token;
             State = TaskState.Waiting;
             Task = task;
+            sourceCancellationToken = token;
         }
 
         public void MakeLinkedCancellationTokenSource()
@@ -64,7 +67,8 @@ public class ModelLoadScheduler : MonoBehaviour
                 Debug.LogError("LinkedCancellationTokenSource already initialized.");
                 return;
             }
-            LinkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(CancellationToken);
+            LinkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(sourceCancellationToken);
+            CancellationToken = LinkedCancellationTokenSource.Token;
         }
 
         public void CancelTask()

--- a/Assets/GeoTileLoader/Components/TileSetNodeComponent.cs
+++ b/Assets/GeoTileLoader/Components/TileSetNodeComponent.cs
@@ -161,7 +161,7 @@ namespace GeoTile
 
         public bool IsModelLoaded()
         {
-            return transform.Find("GLTF") != null;
+            return transform.Find(IGltfInstantiator.GltfGameObjectName) != null;
         }
 
         async UniTask<bool> LoadModelIfNotLoaded(CancellationToken token)
@@ -228,7 +228,7 @@ namespace GeoTile
                     return false;
                 }
             }
-            await InstatiateGltf(modelData.Data, modelData.CenterPosition);
+            await InstatiateGltf(modelData.Data, modelData.CenterPosition, token);
             return true;
         }
 
@@ -334,7 +334,7 @@ namespace GeoTile
             };
         }
 
-        async UniTask<bool> InstatiateGltf(byte[] gltfData, double[] center)
+        async UniTask<bool> InstatiateGltf(byte[] gltfData, double[] center, CancellationToken token)
         {
             var component = this;
             this.gltfCenter = center;
@@ -344,7 +344,7 @@ namespace GeoTile
             {
                 return false;
             }
-            var (result, metadata) = await gltfInstantiator.Instantiate(gltfData, center, this, this.GetCancellationTokenOnDestroy());
+            var (result, metadata) = await gltfInstantiator.Instantiate(gltfData, center, this, token);
 
             // Copyrightを格納する
             if (!string.IsNullOrEmpty(metadata?.Copyright))

--- a/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
+++ b/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
@@ -26,7 +26,7 @@ namespace GeoTile
         {
             var contentUrl = Target.TileSetNode?.content?.Url;
             var contentFound = !string.IsNullOrEmpty(contentUrl);
-            var alreadyLoaded = Target.transform.Find("GLTF") != null;
+            var alreadyLoaded = Target.transform.Find(IGltfInstantiator.GltfGameObjectName) != null;
             var contentExtension = Target.GetContentExtension();
             var jsonFound = contentExtension != null && contentExtension.EndsWith(".json");
 

--- a/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
+++ b/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
@@ -101,26 +101,49 @@ namespace GeoTile
             var gltf = new GltfImport(logger: new UnityLogger());
             try
             {
+                // GLTFのバイナリ読み込み
                 bool success = await gltf.LoadGltfBinary(data, baseUri, cancellationToken: token);
+                // 2024/12/8時点で、GltfImport.LoadGltfBinary() では、
+                // CancellationTokenが機能していないのでここでキャンセルをチェック
+                token.ThrowIfCancellationRequested();
                 if (!success)
                 {
                     Debug.LogError("load gltf failed.");
                     return (null, null);
                 }
             }
-            catch (Exception e)
+            catch (OperationCanceledException e)
             {
+                gltf.Dispose();
+                Debug.LogWarning("GLTF Load Cancelled.");
+                throw;
+            }
+            catch (Exception e) when (!(e is OperationCanceledException))
+            {
+                gltf.Dispose();
                 Debug.LogError("load gltf error. " + e);
                 return (null, null);
             }
 
             var copyright = gltf.GetSourceRoot().asset.copyright;
-
-            var go = new GameObject("GLTF");
+            
+            var go = new GameObject(IGltfInstantiator.GltfGameObjectName);
             go.transform.SetParent(parent, false);
-            {
+            try {
+                // GLTFのインスタンス化
                 bool success = await gltf.InstantiateMainSceneAsync(go.transform, cancellationToken: token);
+                // 2024/12/8時点で、GltfImport.InstantiateMainSceneAsync() では、
+                // CancellationTokenが機能していないのでここでキャンセルをチェック
+                token.ThrowIfCancellationRequested();
                 Debug.Log("load gltf result: " + success);
+            }
+            catch(OperationCanceledException _)
+            {
+                gltf.Dispose();
+                Debug.LogWarning("GLTF Instantiate  Cancelled.");
+                // キャンセル時、作成したGameObjectを消す
+                UnityEngine.Object.Destroy(go);
+                throw;
             }
 
             return (go, copyright);

--- a/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithUniGltf.cs
+++ b/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithUniGltf.cs
@@ -95,7 +95,7 @@ namespace GeoTile
             //File.WriteAllBytes(filePath, data);
             //Debug.Log($"GLTF written to <{filePath}>");
 
-            var gltfData = new GlbBinaryParser(data, "GLTF").Parse();
+            var gltfData = new GlbBinaryParser(data, IGltfInstantiator.GltfGameObjectName).Parse();
             using var loader = new UniGLTF.ImporterContext(gltfData);
             var instance = await loader.LoadAsync(new ImmediateCaller());
             instance.EnableUpdateWhenOffscreen();

--- a/Assets/GeoTileLoader/Scripts/IGltfInstantiator.cs
+++ b/Assets/GeoTileLoader/Scripts/IGltfInstantiator.cs
@@ -19,6 +19,7 @@ namespace GeoTile
     /// </summary>
     public interface IGltfInstantiator
     {
+        static readonly string GltfGameObjectName = "__GLTF__";
         UniTask<(bool, TileMeshMetadata)> Instantiate(byte[] gltfData, double[] center, TileSetNodeComponent component, CancellationToken token);
     }
 


### PR DESCRIPTION
fix #24 

# 概要

ModelLoadScheduler.StopAllTasks() を利用してロードをキャンセルした時、GLTFというGameObjectと、地図の断片モデルが残ることがある現象を修正。

# 詳細

３つの問題があったと考えられる。
* CancellationTokenの伝播が途中で止まっている問題
* TaskCarrierで、LinkedCancellationTokenSourceがまともに利用されていなかった問題
* glTFastのコードがCancellationTokenを受け入れるのに、妥当な処理を行っていない問題

# 対策

* CancellationTokenの伝播を修正
* LinkedCancellationTokenSourceから出力されたTokenが利用されるよう修正
* glTFastのasyncコード実行後にCancellationToken.ThrowIfCancellationRequested()の実行
