### PR TITLE
rename TileSetManager's Parent to TileSetParent, fix warnings

### DIFF
--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
@@ -188,7 +188,7 @@ public class ModelLoadScheduler : MonoBehaviour
                     carrier.Exception = new Exception("the task returned failure.");
                 }
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException)
             {
                 carrier.State = TaskState.Cancelled;
             }

--- a/Assets/GeoTileLoader/Components/TileSetManager.cs
+++ b/Assets/GeoTileLoader/Components/TileSetManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
+using UnityEngine.Serialization;
 
 namespace GeoTile
 {
@@ -41,13 +42,13 @@ namespace GeoTile
             set => settings = value;
         }
         
-        [SerializeField]
-        private Transform parent;
+        [FormerlySerializedAs("parent")] [SerializeField]
+        private Transform tileSetParent;
 
-        public Transform Parent
+        public Transform TileSetParent
         {
-            get => parent;
-            set => parent = value;
+            get => tileSetParent;
+            set => tileSetParent = value;
         }
 
         public CullingInfo cullingInfo = new CullingInfo()
@@ -92,7 +93,7 @@ namespace GeoTile
                 TileSetName = tileSetTitle,
                 TileSetJsonUrl = tileSetJsonUrl,
                 GoogleMapTileApiKey = settings?.GoogleApiKeyFor3dMapTiles,
-                RootParent = parent,
+                RootParent = tileSetParent,
                 CullingInfo = cullingInfo,
             });
             return await loader.ReadJson(null, parentTrans, cullingInfo.cullCollider, token);

--- a/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
+++ b/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
@@ -112,7 +112,7 @@ namespace GeoTile
                     return (null, null);
                 }
             }
-            catch (OperationCanceledException e)
+            catch (OperationCanceledException)
             {
                 gltf.Dispose();
                 Debug.LogWarning("GLTF Load Cancelled.");
@@ -137,7 +137,7 @@ namespace GeoTile
                 token.ThrowIfCancellationRequested();
                 Debug.Log("load gltf result: " + success);
             }
-            catch(OperationCanceledException _)
+            catch(OperationCanceledException)
             {
                 gltf.Dispose();
                 Debug.LogWarning("GLTF Instantiate  Cancelled.");

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -101,7 +101,7 @@ namespace GeoTile
             var node = trans.GetComponent<TileSetNodeComponent>();
             if (node != null)
             {
-                await Load3DModelForNode(node, token);
+                AddLoad3DModelTaskForNode(node, token);
             }
 
             foreach (Transform child in trans)
@@ -129,7 +129,7 @@ namespace GeoTile
             }
         }
 
-        private async UniTask Load3DModelForNode(TileSetNodeComponent node, CancellationToken token)
+        private void AddLoad3DModelTaskForNode(TileSetNodeComponent node, CancellationToken token)
         {
             if (node.GetContentExtension() != ".b3dm" && node.GetContentExtension() != ".glb")
             {


### PR DESCRIPTION
renamed, because it can be easily mis-understood as unity's parent transform of TileSetManager.