### PR TITLE
fix slow tree node loading, implement concurrent tree node loading

### DIFF
--- a/Assets/GeoTileLoader.Samples/Scripts/SampleUI.cs
+++ b/Assets/GeoTileLoader.Samples/Scripts/SampleUI.cs
@@ -75,6 +75,7 @@ namespace GeoTile.Samples
             {
                 try
                 {
+                    JsonLoadScheduler.Instance?.StopAllTasks();
                     ModelLoadScheduler.Instance?.StopAllTasks();
                     cts = new CancellationTokenSource();
                     isBusy = true;
@@ -152,6 +153,7 @@ namespace GeoTile.Samples
             cts?.Cancel();
             cts?.Dispose();
             cts = null;
+            JsonLoadScheduler.Instance?.StopAllTasks();
             ModelLoadScheduler.Instance?.StopAllTasks();
         }
     }

--- a/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
@@ -3,199 +3,90 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using System;
 using System.Linq;
-using GeoTile;
 
-/// <summary>
-/// Scheduler for JSON loading tasks with concurrent execution support
-/// Singleton MonoBehaviour that manages JSON loading operations
-/// </summary>
-public class JsonLoadScheduler : MonoBehaviour
+namespace GeoTile
 {
     /// <summary>
-    /// Task implementation for subtree loading operations (wraps original LoadSubTreesRecursive logic)
+    /// Scheduler for JSON loading tasks with concurrent execution support
+    /// Singleton MonoBehaviour that manages JSON loading operations
     /// </summary>
-    public class LoadSubTreeTask : GeoTile.TaskScheduler.Task
+    public class JsonLoadScheduler : MonoBehaviour
     {
-        private readonly TileSetHierarchy hierarchy;
-        private readonly Transform trans;
-        private readonly int maxLevels;
-        private readonly int maxNodes;
 
-        public LoadSubTreeTask(TileSetHierarchy hierarchy, Transform trans, int maxLevels, int maxNodes)
+        private static JsonLoadScheduler instance;
+        public static JsonLoadScheduler Instance => instance;
+
+        private TaskScheduler taskScheduler;
+
+        // Configure concurrency limit for JSON loading (lower than model loading to avoid overwhelming servers)
+        private const int JsonConcurrencyLimit = 10;
+
+        public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
+
+        public static void CreateGameObject()
         {
-            this.hierarchy = hierarchy;
-            this.trans = trans;
-            this.maxLevels = maxLevels;
-            this.maxNodes = maxNodes;
+            var go = new GameObject("JsonLoadScheduler");
+            go.AddComponent<JsonLoadScheduler>();
         }
 
-        public async UniTask<(bool result, object artifact)> Do(CancellationToken token)
+        private void Awake()
         {
-            try
+            if (instance != null && instance != this)
             {
-                var remainingNodes = await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
-                return (true, remainingNodes);
+                Destroy(gameObject);
+                return;
             }
-            catch (Exception e)
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            taskScheduler = new TaskScheduler(JsonConcurrencyLimit, "JsonLoadScheduler");
+        }
+
+        private void Update()
+        {
+            taskScheduler?.ProcessTasks();
+        }
+
+        private void OnDestroy()
+        {
+            taskScheduler?.StopAllTasks();
+            if (instance == this)
             {
-                Debug.LogError($"LoadSubTreeTask failed for {trans.name}: {e}");
-                return (false, null);
+                instance = null;
             }
         }
 
-        private async UniTask<int> LoadSubTreesRecursiveLogic(Transform trans, int maxLevels, int maxNodes, CancellationToken token)
+        /// <summary>
+        /// Add a subtree loading task to the queue
+        /// </summary>
+        /// <param name="name">Task name for debugging</param>
+        /// <param name="hierarchy">TileSetHierarchy instance</param>
+        /// <param name="trans">Transform to process</param>
+        /// <param name="maxLevels">Maximum levels to process</param>
+        /// <param name="maxNodes">Maximum nodes to process</param>
+        /// <param name="token">Cancellation token</param>
+        /// <param name="priority">Task priority (higher values executed first)</param>
+        /// <returns>Task carrier for tracking progress</returns>
+        public TaskScheduler.TaskCarrier AddLoadSubTreeTask(
+            string name,
+            TileSetHierarchy hierarchy,
+            Transform trans,
+            int maxLevels,
+            int maxNodes,
+            CancellationToken token,
+            float priority = 0)
         {
-            maxNodes--;
-            if (maxNodes <= 0)
-            {
-                Debug.LogWarning("maxNodes reached.");
-                return maxNodes;
-            }
-
-            // サブツリーが存在して、既にロードされていなければロードする
-            var node = trans.GetComponent<TileSetNodeComponent>();
-            if (node != null
-                && node.gameObject.activeInHierarchy
-                && node.SubTreeExists()
-                && !node.SubTreeAlreadyLoaded())
-            {
-                var contentUrl = node.TileSetNode?.content?.Url;
-                var newUri = new Uri(new Uri(node.BaseJsonUrl), contentUrl);
-                var query = node.TileSetNode?.content?.contentUrlQuery;
-                Debug.Log("content query:" + query);
-                var sessionId = node.GoogleSessionId;
-                var sessionKeyValue = query.Split("&").Select(v => v.Split("=")).Where(kv => kv[0] == "session")
-                    .ToList();
-                if (sessionKeyValue.Count > 0)
-                {
-                    sessionId = sessionKeyValue[0][1];
-                }
-
-                var config = new TileSetHierarchyLoaderConfig()
-                {
-                    TileSetJsonUrl = newUri.ToString(),
-                    TileSetName = "",
-                    GoogleSessionId = sessionId,
-                    GoogleMapTileApiKey = node.TileSetInfoProvider.LoaderConfig.GoogleMapTileApiKey,
-                    CullingInfo = node.CullingInfo,
-                    RootParent = node.TileSetInfoProvider.LoaderConfig.RootParent,
-                };
-                try
-                {
-                    var loader = new TileSetHierarchyLoader(config);
-                    await loader.ReadJsonAsync(hierarchy, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
-                    Debug.Log($"ReadJson at {trans.name} success.");
-                }
-                catch (Exception e)
-                {
-                    Debug.LogError($"ReadJson at {trans.name} failed. e: " + e);
-                }
-            }
-
-            // 子ノードの処理をタスクとして追加（再帰呼び出しの代わり）
-            foreach (Transform child in trans)
-            {
-                var childNode = child.GetComponent<TileSetNodeComponent>();
-                if (childNode != null && childNode.gameObject.activeInHierarchy)
-                {
-                    if (maxLevels > 1 && maxNodes > 0)
-                    {
-                        float priority = 0;
-                        JsonLoadScheduler.Instance.AddLoadSubTreeTask(
-                            $"SubTree-{child.name}",
-                            hierarchy,
-                            child,
-                            maxLevels - 1,
-                            maxNodes,
-                            token,
-                            priority
-                        );
-                        maxNodes--;
-                        if (maxNodes <= 0)
-                        {
-                            break;
-                        }
-                    }
-                }
-            }
-
-            return maxNodes;
+            var task = new LoadSubTreeTask(hierarchy, trans, maxLevels, maxNodes);
+            return taskScheduler.AddTask(name, token, priority, task);
         }
-    }
 
-    private static JsonLoadScheduler instance;
-    public static JsonLoadScheduler Instance => instance;
-
-    private GeoTile.TaskScheduler taskScheduler;
-    
-    // Configure concurrency limit for JSON loading (lower than model loading to avoid overwhelming servers)
-    private const int JsonConcurrencyLimit = 10;
-
-    public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
-
-    public static void CreateGameObject()
-    {
-        var go = new GameObject("JsonLoadScheduler");
-        go.AddComponent<JsonLoadScheduler>();
-    }
-
-    private void Awake()
-    {
-        if (instance != null && instance != this)
+        /// <summary>
+        /// Stop all queued and running JSON loading tasks
+        /// </summary>
+        public void StopAllTasks()
         {
-            Destroy(gameObject);
-            return;
+            taskScheduler?.StopAllTasks();
         }
-        
-        instance = this;
-        DontDestroyOnLoad(gameObject);
-        
-        taskScheduler = new GeoTile.TaskScheduler(JsonConcurrencyLimit, "JsonLoadScheduler");
-    }
-
-    private void Update()
-    {
-        taskScheduler?.ProcessTasks();
-    }
-
-    private void OnDestroy()
-    {
-        taskScheduler?.StopAllTasks();
-        if (instance == this)
-        {
-            instance = null;
-        }
-    }
-
-    /// <summary>
-    /// Add a subtree loading task to the queue
-    /// </summary>
-    /// <param name="name">Task name for debugging</param>
-    /// <param name="hierarchy">TileSetHierarchy instance</param>
-    /// <param name="trans">Transform to process</param>
-    /// <param name="maxLevels">Maximum levels to process</param>
-    /// <param name="maxNodes">Maximum nodes to process</param>
-    /// <param name="token">Cancellation token</param>
-    /// <param name="priority">Task priority (higher values executed first)</param>
-    /// <returns>Task carrier for tracking progress</returns>
-    public GeoTile.TaskScheduler.TaskCarrier AddLoadSubTreeTask(
-        string name,
-        TileSetHierarchy hierarchy,
-        Transform trans,
-        int maxLevels,
-        int maxNodes,
-        CancellationToken token,
-        float priority = 0)
-    {
-        var task = new LoadSubTreeTask(hierarchy, trans, maxLevels, maxNodes);
-        return taskScheduler.AddTask(name, token, priority, task);
-    }
-
-    /// <summary>
-    /// Stop all queued and running JSON loading tasks
-    /// </summary>
-    public void StopAllTasks()
-    {
-        taskScheduler?.StopAllTasks();
     }
 }

--- a/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
@@ -1,0 +1,201 @@
+using UnityEngine;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using System;
+using System.Linq;
+using GeoTile;
+
+/// <summary>
+/// Scheduler for JSON loading tasks with concurrent execution support
+/// Singleton MonoBehaviour that manages JSON loading operations
+/// </summary>
+public class JsonLoadScheduler : MonoBehaviour
+{
+    /// <summary>
+    /// Task implementation for subtree loading operations (wraps original LoadSubTreesRecursive logic)
+    /// </summary>
+    public class LoadSubTreeTask : GeoTile.TaskScheduler.Task
+    {
+        private readonly TileSetHierarchy hierarchy;
+        private readonly Transform trans;
+        private readonly int maxLevels;
+        private readonly int maxNodes;
+
+        public LoadSubTreeTask(TileSetHierarchy hierarchy, Transform trans, int maxLevels, int maxNodes)
+        {
+            this.hierarchy = hierarchy;
+            this.trans = trans;
+            this.maxLevels = maxLevels;
+            this.maxNodes = maxNodes;
+        }
+
+        public async UniTask<(bool result, object artifact)> Do(CancellationToken token)
+        {
+            try
+            {
+                var remainingNodes = await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
+                return (true, remainingNodes);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"LoadSubTreeTask failed for {trans.name}: {e}");
+                return (false, null);
+            }
+        }
+
+        private async UniTask<int> LoadSubTreesRecursiveLogic(Transform trans, int maxLevels, int maxNodes, CancellationToken token)
+        {
+            maxNodes--;
+            if (maxNodes <= 0)
+            {
+                Debug.LogWarning("maxNodes reached.");
+                return maxNodes;
+            }
+
+            // サブツリーが存在して、既にロードされていなければロードする
+            var node = trans.GetComponent<TileSetNodeComponent>();
+            if (node != null
+                && node.gameObject.activeInHierarchy
+                && node.SubTreeExists()
+                && !node.SubTreeAlreadyLoaded())
+            {
+                var contentUrl = node.TileSetNode?.content?.Url;
+                var newUri = new Uri(new Uri(node.BaseJsonUrl), contentUrl);
+                var query = node.TileSetNode?.content?.contentUrlQuery;
+                Debug.Log("content query:" + query);
+                var sessionId = node.GoogleSessionId;
+                var sessionKeyValue = query.Split("&").Select(v => v.Split("=")).Where(kv => kv[0] == "session")
+                    .ToList();
+                if (sessionKeyValue.Count > 0)
+                {
+                    sessionId = sessionKeyValue[0][1];
+                }
+
+                var config = new TileSetHierarchyLoaderConfig()
+                {
+                    TileSetJsonUrl = newUri.ToString(),
+                    TileSetName = "",
+                    GoogleSessionId = sessionId,
+                    GoogleMapTileApiKey = node.TileSetInfoProvider.LoaderConfig.GoogleMapTileApiKey,
+                    CullingInfo = node.CullingInfo,
+                    RootParent = node.TileSetInfoProvider.LoaderConfig.RootParent,
+                };
+                try
+                {
+                    var loader = new TileSetHierarchyLoader(config);
+                    await loader.ReadJsonAsync(hierarchy, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
+                    Debug.Log($"ReadJson at {trans.name} success.");
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"ReadJson at {trans.name} failed. e: " + e);
+                }
+            }
+
+            // 子ノードの処理をタスクとして追加（再帰呼び出しの代わり）
+            foreach (Transform child in trans)
+            {
+                var childNode = child.GetComponent<TileSetNodeComponent>();
+                if (childNode != null && childNode.gameObject.activeInHierarchy)
+                {
+                    if (maxLevels > 1 && maxNodes > 0)
+                    {
+                        float priority = 0;
+                        JsonLoadScheduler.Instance.AddLoadSubTreeTask(
+                            $"SubTree-{child.name}",
+                            hierarchy,
+                            child,
+                            maxLevels - 1,
+                            maxNodes,
+                            token,
+                            priority
+                        );
+                        maxNodes--;
+                        if (maxNodes <= 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return maxNodes;
+        }
+    }
+
+    private static JsonLoadScheduler instance;
+    public static JsonLoadScheduler Instance => instance;
+
+    private GeoTile.TaskScheduler taskScheduler;
+    
+    // Configure concurrency limit for JSON loading (lower than model loading to avoid overwhelming servers)
+    private const int JsonConcurrencyLimit = 10;
+
+    public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
+
+    public static void CreateGameObject()
+    {
+        var go = new GameObject("JsonLoadScheduler");
+        go.AddComponent<JsonLoadScheduler>();
+    }
+
+    private void Awake()
+    {
+        if (instance != null && instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        
+        instance = this;
+        DontDestroyOnLoad(gameObject);
+        
+        taskScheduler = new GeoTile.TaskScheduler(JsonConcurrencyLimit, "JsonLoadScheduler");
+    }
+
+    private void Update()
+    {
+        taskScheduler?.ProcessTasks();
+    }
+
+    private void OnDestroy()
+    {
+        taskScheduler?.StopAllTasks();
+        if (instance == this)
+        {
+            instance = null;
+        }
+    }
+
+    /// <summary>
+    /// Add a subtree loading task to the queue
+    /// </summary>
+    /// <param name="name">Task name for debugging</param>
+    /// <param name="hierarchy">TileSetHierarchy instance</param>
+    /// <param name="trans">Transform to process</param>
+    /// <param name="maxLevels">Maximum levels to process</param>
+    /// <param name="maxNodes">Maximum nodes to process</param>
+    /// <param name="token">Cancellation token</param>
+    /// <param name="priority">Task priority (higher values executed first)</param>
+    /// <returns>Task carrier for tracking progress</returns>
+    public GeoTile.TaskScheduler.TaskCarrier AddLoadSubTreeTask(
+        string name,
+        TileSetHierarchy hierarchy,
+        Transform trans,
+        int maxLevels,
+        int maxNodes,
+        CancellationToken token,
+        float priority = 0)
+    {
+        var task = new LoadSubTreeTask(hierarchy, trans, maxLevels, maxNodes);
+        return taskScheduler.AddTask(name, token, priority, task);
+    }
+
+    /// <summary>
+    /// Stop all queued and running JSON loading tasks
+    /// </summary>
+    public void StopAllTasks()
+    {
+        taskScheduler?.StopAllTasks();
+    }
+}

--- a/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
@@ -91,7 +91,6 @@ namespace GeoTile
         /// <param name="hierarchy">TileSetHierarchy instance</param>
         /// <param name="trans">Transform to process</param>
         /// <param name="maxLevels">Maximum levels to process</param>
-        /// <param name="maxNodes">Maximum nodes to process</param>
         /// <param name="token">Cancellation token</param>
         /// <param name="priority">Task priority (higher values executed first)</param>
         /// <returns>Task carrier for tracking progress</returns>
@@ -100,11 +99,10 @@ namespace GeoTile
             TileSetHierarchy hierarchy,
             Transform trans,
             int maxLevels,
-            int maxNodes,
             CancellationToken token,
             float priority = 0)
         {
-            var task = new LoadSubTreeTask(hierarchy, trans, maxLevels, maxNodes);
+            var task = new LoadSubTreeTask(hierarchy, trans, maxLevels);
             return taskScheduler.AddTask(name, token, priority, task);
         }
 

--- a/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs
@@ -3,6 +3,7 @@ using System.Threading;
 using Cysharp.Threading.Tasks;
 using System;
 using System.Linq;
+using System.Collections;
 
 namespace GeoTile
 {
@@ -18,8 +19,8 @@ namespace GeoTile
 
         private TaskScheduler taskScheduler;
 
-        // Configure concurrency limit for JSON loading (lower than model loading to avoid overwhelming servers)
-        private const int JsonConcurrencyLimit = 10;
+        // Configure concurrency limit for JSON loading
+        private const int JsonConcurrencyLimit = 20;
 
         public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
 
@@ -43,9 +44,35 @@ namespace GeoTile
             taskScheduler = new TaskScheduler(JsonConcurrencyLimit, "JsonLoadScheduler");
         }
 
+        private void Start()
+        {
+            // 5秒間隔でrunningTasksの状態をログ出力するコルーチンを開始
+            StartCoroutine(LogRunningTasksCoroutine());
+        }
+
         private void Update()
         {
             taskScheduler?.ProcessTasks();
+        }
+
+        /// <summary>
+        /// 10秒間隔でrunningTasksの状態をログ出力するコルーチン
+        /// </summary>
+        private IEnumerator LogRunningTasksCoroutine()
+        {
+            while (true)
+            {
+                yield return new WaitForSeconds(10.0f);
+                if (taskScheduler == null)
+                {
+                    continue;
+                }
+                if (taskScheduler.RemainingTasksCount == 0)
+                {
+                    continue;
+                }
+                Debug.Log(taskScheduler.GetRunningTasksInfo());
+            }
         }
 
         private void OnDestroy()

--- a/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs.meta
+++ b/Assets/GeoTileLoader/Components/JsonLoadScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2ecab5b7b3012435282f46cc9e385e99
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
@@ -1,78 +1,80 @@
 using UnityEngine;
 using System.Threading;
-using GeoTile;
 
-/// <summary>
-/// モデルロードをスロットリングするクラス
-/// TaskSchedulerを内部的に使用するMonoBehaviourラッパー
-/// </summary>
-public class ModelLoadScheduler : MonoBehaviour
+namespace GeoTile
 {
-    private static ModelLoadScheduler instance;
-    public static ModelLoadScheduler Instance => instance;
-
-    private GeoTile.TaskScheduler taskScheduler;
-    
-    const int concurrencyLimit = 8;
-
-    public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
-
-    public static void CreateGameObject()
-    {
-        var go = new GameObject("ModelLoadScheduler");
-        go.AddComponent<ModelLoadScheduler>();
-    }
-
-    private void Awake()
-    {
-        if (instance != null && instance != this)
-        {
-            Destroy(gameObject);
-            return;
-        }
-        
-        instance = this;
-        DontDestroyOnLoad(gameObject);
-        
-        taskScheduler = new GeoTile.TaskScheduler(concurrencyLimit, "ModelLoadScheduler");
-    }
-
-    void Start()
-    {
-    }
-
-    void Update()
-    {
-        taskScheduler?.ProcessTasks();
-    }
-
-    private void OnDestroy()
-    {
-        taskScheduler?.StopAllTasks();
-        if (instance == this)
-        {
-            instance = null;
-        }
-    }
-
     /// <summary>
-    /// タスクをキューに追加する
+    /// モデルロードをスロットリングするクラス
+    /// TaskSchedulerを内部的に使用するMonoBehaviourラッパー
     /// </summary>
-    /// <param name="name"></param>
-    /// <param name="token"></param>
-    /// <param name="priority"></param>
-    /// <param name="task"></param>
-    /// <returns></returns>
-    public GeoTile.TaskScheduler.TaskCarrier AddTask(string name, CancellationToken token, float priority, GeoTile.TaskScheduler.Task task)
+    public class ModelLoadScheduler : MonoBehaviour
     {
-        return taskScheduler.AddTask(name, token, priority, task);
-    }
+        private static ModelLoadScheduler instance;
+        public static ModelLoadScheduler Instance => instance;
 
-    /// <summary>
-    /// キューイングされたすべてのタスクを止めて、タスクキューをクリアする。
-    /// </summary>
-    public void StopAllTasks()
-    {
-        taskScheduler?.StopAllTasks();
+        private TaskScheduler taskScheduler;
+
+        const int concurrencyLimit = 8;
+
+        public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
+
+        public static void CreateGameObject()
+        {
+            var go = new GameObject("ModelLoadScheduler");
+            go.AddComponent<ModelLoadScheduler>();
+        }
+
+        private void Awake()
+        {
+            if (instance != null && instance != this)
+            {
+                Destroy(gameObject);
+                return;
+            }
+
+            instance = this;
+            DontDestroyOnLoad(gameObject);
+
+            taskScheduler = new TaskScheduler(concurrencyLimit, "ModelLoadScheduler");
+        }
+
+        void Start()
+        {
+        }
+
+        void Update()
+        {
+            taskScheduler?.ProcessTasks();
+        }
+
+        private void OnDestroy()
+        {
+            taskScheduler?.StopAllTasks();
+            if (instance == this)
+            {
+                instance = null;
+            }
+        }
+
+        /// <summary>
+        /// タスクをキューに追加する
+        /// </summary>
+        /// <param name="name"></param>
+        /// <param name="token"></param>
+        /// <param name="priority"></param>
+        /// <param name="task"></param>
+        /// <returns></returns>
+        public TaskScheduler.TaskCarrier AddTask(string name, CancellationToken token, float priority, TaskScheduler.Task task)
+        {
+            return taskScheduler.AddTask(name, token, priority, task);
+        }
+
+        /// <summary>
+        /// キューイングされたすべてのタスクを止めて、タスクキューをクリアする。
+        /// </summary>
+        public void StopAllTasks()
+        {
+            taskScheduler?.StopAllTasks();
+        }
     }
 }

--- a/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
+++ b/Assets/GeoTileLoader/Components/ModelLoadScheduler.cs
@@ -1,106 +1,21 @@
-﻿using UnityEngine;
-using System.Collections;
-using Cysharp.Threading.Tasks;
+using UnityEngine;
 using System.Threading;
-using System.Collections.Generic;
-using System;
-
+using GeoTile;
 
 /// <summary>
 /// モデルロードをスロットリングするクラス
-/// 汎用の作りをしているので、実はモデルロード以外にも利用可能。
+/// TaskSchedulerを内部的に使用するMonoBehaviourラッパー
 /// </summary>
 public class ModelLoadScheduler : MonoBehaviour
 {
-    public enum TaskState
-    {
-        Waiting,
-        Running,
-        Success,
-        Failed,
-        Cancelled,
-    }
-
-    /// <summary>
-    /// 実行対象のタスク
-    /// </summary>
-    public interface Task
-    {
-        UniTask<(bool result, object artifact)> Do(CancellationToken token);
-    }
-
-    /// <summary>
-    /// タスクのメタデータを保持するCarrier
-    /// </summary>
-    public class TaskCarrier : IDisposable
-    {
-        public string Name { get; }
-
-        // priorityの高い順に実行される。後から変更も可能。
-        // 現時点で実行順の調整処理は未実装 (2024/9/16)
-        public float Priority { get; set; }
-        
-        private CancellationToken sourceCancellationToken;
-
-        public CancellationToken CancellationToken { get; private set; }
-
-        // ModelLoadSchedulerからもキャンセルしたいので、元のCancellationTokenとリンクしたCancellationTokenSourceを作成して保持する。
-        public CancellationTokenSource LinkedCancellationTokenSource { get; private set; }
-
-        public TaskState State { get; set; }
-        public Exception Exception { get; set; }
-
-        public Task Task { get; }
-
-        public TaskCarrier(string name, CancellationToken token, Task task)
-        {
-            Name = name;
-            State = TaskState.Waiting;
-            Task = task;
-            sourceCancellationToken = token;
-        }
-
-        public void MakeLinkedCancellationTokenSource()
-        {
-            if (LinkedCancellationTokenSource != null)
-            {
-                Debug.LogError("LinkedCancellationTokenSource already initialized.");
-                return;
-            }
-            LinkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(sourceCancellationToken);
-            CancellationToken = LinkedCancellationTokenSource.Token;
-        }
-
-        public void CancelTask()
-        {
-            LinkedCancellationTokenSource?.Cancel();
-        }
-
-        public void Dispose()
-        {
-            if (LinkedCancellationTokenSource != null)
-            {
-                ((IDisposable)LinkedCancellationTokenSource).Dispose();
-            }
-        }
-    }
-
     private static ModelLoadScheduler instance;
     public static ModelLoadScheduler Instance => instance;
 
-    /// <summary>
-    /// 待機中のタスクリスト
-    /// </summary>
-    private List<TaskCarrier> waitingTasks = new List<TaskCarrier>();
-
-    /// <summary>
-    /// 実行中のタスクリスト
-    /// </summary>
-    private List<TaskCarrier> runningTasks = new List<TaskCarrier>();
-
+    private GeoTile.TaskScheduler taskScheduler;
+    
     const int concurrencyLimit = 8;
 
-    public int RemainingTasksCount => waitingTasks.Count + runningTasks.Count;
+    public int RemainingTasksCount => taskScheduler?.RemainingTasksCount ?? 0;
 
     public static void CreateGameObject()
     {
@@ -110,8 +25,16 @@ public class ModelLoadScheduler : MonoBehaviour
 
     private void Awake()
     {
+        if (instance != null && instance != this)
+        {
+            Destroy(gameObject);
+            return;
+        }
+        
         instance = this;
-        DontDestroyOnLoad(this.gameObject);
+        DontDestroyOnLoad(gameObject);
+        
+        taskScheduler = new GeoTile.TaskScheduler(concurrencyLimit, "ModelLoadScheduler");
     }
 
     void Start()
@@ -120,12 +43,16 @@ public class ModelLoadScheduler : MonoBehaviour
 
     void Update()
     {
-        RunNextTasks();
+        taskScheduler?.ProcessTasks();
     }
 
     private void OnDestroy()
     {
-        StopAllTasks();
+        taskScheduler?.StopAllTasks();
+        if (instance == this)
+        {
+            instance = null;
+        }
     }
 
     /// <summary>
@@ -136,73 +63,9 @@ public class ModelLoadScheduler : MonoBehaviour
     /// <param name="priority"></param>
     /// <param name="task"></param>
     /// <returns></returns>
-    public TaskCarrier AddTask(string name, CancellationToken token, float priority, ModelLoadScheduler.Task task)
+    public GeoTile.TaskScheduler.TaskCarrier AddTask(string name, CancellationToken token, float priority, GeoTile.TaskScheduler.Task task)
     {
-        var carrier = new TaskCarrier(name, token, task);
-        carrier.Priority = priority;
-        waitingTasks.Add(carrier);
-        return carrier;
-    }
-
-    /// <summary>
-    /// スロットの空きがあり、残りタスクがあればタスクを実行する
-    /// </summary>
-    void RunNextTasks()
-    {
-        while (runningTasks.Count < concurrencyLimit && waitingTasks.Count > 0)
-        {
-            var carrier = waitingTasks[0];
-            waitingTasks.RemoveAt(0);
-            if (carrier.CancellationToken.IsCancellationRequested)
-            {
-                Debug.Log($"Didn't run the task {carrier.Name} because it is already cancelled.");
-                return;
-            }
-            RunTask(carrier);
-        }
-    }
-
-    /// <summary>
-    /// 該当タスクを実行する
-    /// 実行中、TaskCarrierのStateはRunningになり、runningTasks に入る。
-    /// </summary>
-    /// <param name="task"></param>
-    void RunTask(TaskCarrier carrier)
-    {
-        UniTask.Void(async () =>
-        {
-            try
-            {
-                runningTasks.Add(carrier);
-                carrier.MakeLinkedCancellationTokenSource();
-                carrier.State = TaskState.Running;
-                Debug.Log($"++++ start task {carrier.Name} concurrency: {runningTasks.Count}");
-                var result = await carrier.Task.Do(carrier.CancellationToken);
-                if (result.result)
-                {
-                    carrier.State = TaskState.Success;
-                }
-                else
-                {
-                    carrier.State = TaskState.Failed;
-                    carrier.Exception = new Exception("the task returned failure.");
-                }
-            }
-            catch (OperationCanceledException)
-            {
-                carrier.State = TaskState.Cancelled;
-            }
-            catch (Exception e)
-            {
-                carrier.State = TaskState.Failed;
-                carrier.Exception = e;
-            }
-            finally
-            {
-                runningTasks.Remove(carrier);
-                Debug.Log($"---- end task {carrier.Name} state: {carrier.State} concurrency: {runningTasks.Count}");
-            }
-        });
+        return taskScheduler.AddTask(name, token, priority, task);
     }
 
     /// <summary>
@@ -210,12 +73,6 @@ public class ModelLoadScheduler : MonoBehaviour
     /// </summary>
     public void StopAllTasks()
     {
-        waitingTasks.Clear();
-        foreach (var carrier in runningTasks)
-        {
-            carrier.CancelTask();
-            carrier.Dispose();
-        }
-        runningTasks.Clear();
+        taskScheduler?.StopAllTasks();
     }
 }

--- a/Assets/GeoTileLoader/Components/TileSetManager.cs
+++ b/Assets/GeoTileLoader/Components/TileSetManager.cs
@@ -96,7 +96,7 @@ namespace GeoTile
                 RootParent = tileSetParent,
                 CullingInfo = cullingInfo,
             });
-            return await loader.ReadJson(null, parentTrans, cullingInfo.cullCollider, token);
+            return await loader.ReadJsonAsync(null, parentTrans, cullingInfo.cullCollider, token);
         }
     }
 }

--- a/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
+++ b/Assets/GeoTileLoader/EditorScripts/TileSetNodeComponentEditor.cs
@@ -61,7 +61,7 @@ namespace GeoTile
                 {
                     try
                     {
-                        await loader.ReadJson(hierarchy, Target.transform, Target.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, Target.GetCancellationTokenOnDestroy());
+                        await loader.ReadJsonAsync(hierarchy, Target.transform, Target.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, Target.GetCancellationTokenOnDestroy());
                         Debug.Log("ReadJson success.");
                     }
                     catch (Exception e)

--- a/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
+++ b/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
@@ -28,8 +28,8 @@ namespace GeoTile
         {
             try
             {
-                var remainingNodes = await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
-                return (true, remainingNodes);
+                await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
+                return (true, null);
             }
             catch (Exception e)
             {
@@ -84,6 +84,7 @@ namespace GeoTile
                 catch (Exception e)
                 {
                     Debug.LogError($"ReadJson at {trans.name} failed. e: " + e);
+                    throw;
                 }
             }
 

--- a/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
+++ b/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
@@ -1,0 +1,120 @@
+using System;
+using System.Linq;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace GeoTile
+{
+    /// <summary>
+    /// Task implementation for subtree loading operations (wraps original LoadSubTreesRecursive logic)
+    /// </summary>
+    public class LoadSubTreeTask : TaskScheduler.Task
+    {
+        private readonly TileSetHierarchy hierarchy;
+        private readonly Transform trans;
+        private readonly int maxLevels;
+        private readonly int maxNodes;
+
+        public LoadSubTreeTask(TileSetHierarchy hierarchy, Transform trans, int maxLevels, int maxNodes)
+        {
+            this.hierarchy = hierarchy;
+            this.trans = trans;
+            this.maxLevels = maxLevels;
+            this.maxNodes = maxNodes;
+        }
+
+        public async UniTask<(bool result, object artifact)> Do(CancellationToken token)
+        {
+            try
+            {
+                var remainingNodes = await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
+                return (true, remainingNodes);
+            }
+            catch (Exception e)
+            {
+                Debug.LogError($"LoadSubTreeTask failed for {trans.name}: {e}");
+                return (false, null);
+            }
+        }
+
+        private async UniTask<int> LoadSubTreesRecursiveLogic(Transform trans, int maxLevels, int maxNodes, CancellationToken token)
+        {
+            maxNodes--;
+            if (maxNodes <= 0)
+            {
+                Debug.LogWarning("maxNodes reached.");
+                return maxNodes;
+            }
+
+            // サブツリーが存在して、既にロードされていなければロードする
+            var node = trans.GetComponent<TileSetNodeComponent>();
+            if (node != null
+                && node.gameObject.activeInHierarchy
+                && node.SubTreeExists()
+                && !node.SubTreeAlreadyLoaded())
+            {
+                var contentUrl = node.TileSetNode?.content?.Url;
+                var newUri = new Uri(new Uri(node.BaseJsonUrl), contentUrl);
+                var query = node.TileSetNode?.content?.contentUrlQuery;
+                Debug.Log("content query:" + query);
+                var sessionId = node.GoogleSessionId;
+                var sessionKeyValue = query.Split("&").Select(v => v.Split("=")).Where(kv => kv[0] == "session")
+                    .ToList();
+                if (sessionKeyValue.Count > 0)
+                {
+                    sessionId = sessionKeyValue[0][1];
+                }
+
+                var config = new TileSetHierarchyLoaderConfig()
+                {
+                    TileSetJsonUrl = newUri.ToString(),
+                    TileSetName = "",
+                    GoogleSessionId = sessionId,
+                    GoogleMapTileApiKey = node.TileSetInfoProvider.LoaderConfig.GoogleMapTileApiKey,
+                    CullingInfo = node.CullingInfo,
+                    RootParent = node.TileSetInfoProvider.LoaderConfig.RootParent,
+                };
+                try
+                {
+                    var loader = new TileSetHierarchyLoader(config);
+                    await loader.ReadJsonAsync(hierarchy, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
+                    Debug.Log($"ReadJson at {trans.name} success.");
+                }
+                catch (Exception e)
+                {
+                    Debug.LogError($"ReadJson at {trans.name} failed. e: " + e);
+                }
+            }
+
+            // 子ノードの処理をタスクとして追加（再帰呼び出しの代わり）
+            foreach (Transform child in trans)
+            {
+                var childNode = child.GetComponent<TileSetNodeComponent>();
+                if (childNode != null && childNode.gameObject.activeInHierarchy)
+                {
+                    if (maxLevels > 1 && maxNodes > 0)
+                    {
+                        float priority = 0;
+                        JsonLoadScheduler.Instance.AddLoadSubTreeTask(
+                            $"SubTree-{child.name}",
+                            hierarchy,
+                            child,
+                            maxLevels - 1,
+                            maxNodes,
+                            token,
+                            priority
+                        );
+                        maxNodes--;
+                        if (maxNodes <= 0)
+                        {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            return maxNodes;
+        }
+    }
+}

--- a/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
+++ b/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs
@@ -14,21 +14,19 @@ namespace GeoTile
         private readonly TileSetHierarchy hierarchy;
         private readonly Transform trans;
         private readonly int maxLevels;
-        private readonly int maxNodes;
 
-        public LoadSubTreeTask(TileSetHierarchy hierarchy, Transform trans, int maxLevels, int maxNodes)
+        public LoadSubTreeTask(TileSetHierarchy hierarchy, Transform trans, int maxLevels)
         {
             this.hierarchy = hierarchy;
             this.trans = trans;
             this.maxLevels = maxLevels;
-            this.maxNodes = maxNodes;
         }
 
         public async UniTask<(bool result, object artifact)> Do(CancellationToken token)
         {
             try
             {
-                await LoadSubTreesRecursiveLogic(trans, maxLevels, maxNodes, token);
+                await LoadSubTreesRecursiveLogic(trans, maxLevels, token);
                 return (true, null);
             }
             catch (Exception e)
@@ -38,13 +36,14 @@ namespace GeoTile
             }
         }
 
-        private async UniTask<int> LoadSubTreesRecursiveLogic(Transform trans, int maxLevels, int maxNodes, CancellationToken token)
+        private async UniTask LoadSubTreesRecursiveLogic(Transform trans, int maxLevels, CancellationToken token)
         {
-            maxNodes--;
-            if (maxNodes <= 0)
+            // 集中管理されたノードカウンターをチェック
+            var nodeCount = hierarchy.IncrementNodeCount();
+            if (nodeCount == -1)
             {
-                Debug.LogWarning("maxNodes reached.");
-                return maxNodes;
+                Debug.LogWarning($"MaxNodeCount ({hierarchy.MaxNodeCount}) reached. Current: {hierarchy.CurrentNodeCount}");
+                return; // 制限に達したので処理を停止
             }
 
             // サブツリーが存在して、既にロードされていなければロードする
@@ -94,7 +93,7 @@ namespace GeoTile
                 var childNode = child.GetComponent<TileSetNodeComponent>();
                 if (childNode != null && childNode.gameObject.activeInHierarchy)
                 {
-                    if (maxLevels > 1 && maxNodes > 0)
+                    if (maxLevels > 1)
                     {
                         float priority = 0;
                         JsonLoadScheduler.Instance.AddLoadSubTreeTask(
@@ -102,20 +101,12 @@ namespace GeoTile
                             hierarchy,
                             child,
                             maxLevels - 1,
-                            maxNodes,
                             token,
                             priority
                         );
-                        maxNodes--;
-                        if (maxNodes <= 0)
-                        {
-                            break;
-                        }
                     }
                 }
             }
-
-            return maxNodes;
         }
     }
 }

--- a/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs.meta
+++ b/Assets/GeoTileLoader/Scripts/LoadSubTreeTask.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ee2225745edee4b16a7f6779c83f4322
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
+++ b/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading;
 using Cysharp.Threading.Tasks;
 using UnityEngine;
+using System.Linq;
 
 namespace GeoTile
 {
@@ -35,7 +36,7 @@ namespace GeoTile
         {
             public string Name { get; }
             public float Priority { get; set; }
-            
+
             private CancellationToken sourceCancellationToken;
             public CancellationToken CancellationToken { get; private set; }
             public CancellationTokenSource LinkedCancellationTokenSource { get; private set; }
@@ -75,14 +76,31 @@ namespace GeoTile
                     ((IDisposable)LinkedCancellationTokenSource).Dispose();
                 }
             }
+            
+            public override string ToString()
+            {
+                var exceptionInfo = Exception != null ? $" Exception: {Exception.Message}" : "";
+                return $"Task[{Name}] State: {State}{exceptionInfo}";
+            }
         }
 
         private readonly List<TaskCarrier> waitingTasks = new List<TaskCarrier>();
         private readonly List<TaskCarrier> runningTasks = new List<TaskCarrier>();
+        private readonly List<TaskCarrier> failedTasks = new List<TaskCarrier>();
         private readonly int concurrencyLimit;
         private readonly string schedulerName;
 
         public int RemainingTasksCount => waitingTasks.Count + runningTasks.Count;
+
+        /// <summary>
+        /// Get running tasks information for debugging
+        /// </summary>
+        public string GetRunningTasksInfo()
+        {
+            string log = $"[JsonLoadScheduler] Running tasks count: {runningTasks.Count}";
+            log += string.Join("\n", runningTasks.Select(c => "  " + c.ToString()));
+            return log;
+        }
 
         public TaskScheduler(int concurrencyLimit = 8, string schedulerName = "TaskScheduler")
         {
@@ -157,6 +175,14 @@ namespace GeoTile
                 {
                     runningTasks.Remove(carrier);
                     Debug.Log($"{schedulerName}: ---- end task {carrier.Name} state: {carrier.State} concurrency: {runningTasks.Count}");
+                    if (carrier.State == TaskState.Failed)
+                    {
+                        failedTasks.Add(carrier);
+                    }
+                    else
+                    {
+                        carrier.Dispose();
+                    }
                 }
             });
         }
@@ -164,7 +190,7 @@ namespace GeoTile
         /// <summary>
         /// Stop all queued and running tasks
         /// </summary>
-        public void StopAllTasks()
+        public void StopAllTasks(bool clearFailedTasks = true)
         {
             waitingTasks.Clear();
             foreach (var carrier in runningTasks)
@@ -173,6 +199,20 @@ namespace GeoTile
                 carrier.Dispose();
             }
             runningTasks.Clear();
+
+            if (clearFailedTasks)
+            {
+                ClearFailedTasks();
+            }
+        }
+        
+        public void ClearFailedTasks()
+        {
+            foreach (var carrier in failedTasks)
+            {
+                carrier.Dispose();
+            }
+            failedTasks.Clear();
         }
     }
 }

--- a/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
+++ b/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
@@ -1,0 +1,178 @@
+using System;
+using System.Collections.Generic;
+using System.Threading;
+using Cysharp.Threading.Tasks;
+using UnityEngine;
+
+namespace GeoTile
+{
+    /// <summary>
+    /// Generic task scheduler that manages concurrent execution of tasks with configurable limits
+    /// </summary>
+    public class TaskScheduler
+    {
+        public enum TaskState
+        {
+            Waiting,
+            Running,
+            Success,
+            Failed,
+            Cancelled,
+        }
+
+        /// <summary>
+        /// Interface for tasks that can be executed by the scheduler
+        /// </summary>
+        public interface Task
+        {
+            UniTask<(bool result, object artifact)> Do(CancellationToken token);
+        }
+
+        /// <summary>
+        /// Container for task metadata and execution state
+        /// </summary>
+        public class TaskCarrier : IDisposable
+        {
+            public string Name { get; }
+            public float Priority { get; set; }
+            
+            private CancellationToken sourceCancellationToken;
+            public CancellationToken CancellationToken { get; private set; }
+            public CancellationTokenSource LinkedCancellationTokenSource { get; private set; }
+
+            public TaskState State { get; set; }
+            public Exception Exception { get; set; }
+            public Task Task { get; }
+
+            public TaskCarrier(string name, CancellationToken token, Task task)
+            {
+                Name = name;
+                State = TaskState.Waiting;
+                Task = task;
+                sourceCancellationToken = token;
+            }
+
+            public void MakeLinkedCancellationTokenSource()
+            {
+                if (LinkedCancellationTokenSource != null)
+                {
+                    Debug.LogError("LinkedCancellationTokenSource already initialized.");
+                    return;
+                }
+                LinkedCancellationTokenSource = CancellationTokenSource.CreateLinkedTokenSource(sourceCancellationToken);
+                CancellationToken = LinkedCancellationTokenSource.Token;
+            }
+
+            public void CancelTask()
+            {
+                LinkedCancellationTokenSource?.Cancel();
+            }
+
+            public void Dispose()
+            {
+                if (LinkedCancellationTokenSource != null)
+                {
+                    ((IDisposable)LinkedCancellationTokenSource).Dispose();
+                }
+            }
+        }
+
+        private readonly List<TaskCarrier> waitingTasks = new List<TaskCarrier>();
+        private readonly List<TaskCarrier> runningTasks = new List<TaskCarrier>();
+        private readonly int concurrencyLimit;
+        private readonly string schedulerName;
+
+        public int RemainingTasksCount => waitingTasks.Count + runningTasks.Count;
+
+        public TaskScheduler(int concurrencyLimit = 8, string schedulerName = "TaskScheduler")
+        {
+            this.concurrencyLimit = concurrencyLimit;
+            this.schedulerName = schedulerName;
+        }
+
+        /// <summary>
+        /// Add a task to the execution queue
+        /// </summary>
+        public TaskCarrier AddTask(string name, CancellationToken token, float priority, Task task)
+        {
+            var carrier = new TaskCarrier(name, token, task);
+            carrier.Priority = priority;
+            waitingTasks.Add(carrier);
+            return carrier;
+        }
+
+        /// <summary>
+        /// Execute next available tasks if there are free slots
+        /// Should be called regularly (e.g., from Update method)
+        /// </summary>
+        public void ProcessTasks()
+        {
+            while (runningTasks.Count < concurrencyLimit && waitingTasks.Count > 0)
+            {
+                var carrier = waitingTasks[0];
+                waitingTasks.RemoveAt(0);
+                if (carrier.CancellationToken.IsCancellationRequested)
+                {
+                    Debug.Log($"{schedulerName}: Didn't run the task {carrier.Name} because it is already cancelled.");
+                    continue;
+                }
+                RunTask(carrier);
+            }
+        }
+
+        /// <summary>
+        /// Execute a specific task
+        /// </summary>
+        private void RunTask(TaskCarrier carrier)
+        {
+            UniTask.Void(async () =>
+            {
+                try
+                {
+                    runningTasks.Add(carrier);
+                    carrier.MakeLinkedCancellationTokenSource();
+                    carrier.State = TaskState.Running;
+                    Debug.Log($"{schedulerName}: ++++ start task {carrier.Name} concurrency: {runningTasks.Count}");
+                    var result = await carrier.Task.Do(carrier.CancellationToken);
+                    if (result.result)
+                    {
+                        carrier.State = TaskState.Success;
+                    }
+                    else
+                    {
+                        carrier.State = TaskState.Failed;
+                        carrier.Exception = new Exception("the task returned failure.");
+                    }
+                }
+                catch (OperationCanceledException)
+                {
+                    carrier.State = TaskState.Cancelled;
+                }
+                catch (Exception e)
+                {
+                    carrier.State = TaskState.Failed;
+                    carrier.Exception = e;
+                }
+                finally
+                {
+                    runningTasks.Remove(carrier);
+                    Debug.Log($"{schedulerName}: ---- end task {carrier.Name} state: {carrier.State} concurrency: {runningTasks.Count}");
+                }
+            });
+        }
+
+        /// <summary>
+        /// Stop all queued and running tasks
+        /// </summary>
+        public void StopAllTasks()
+        {
+            waitingTasks.Clear();
+            foreach (var carrier in runningTasks)
+            {
+                carrier.CancelTask();
+                carrier.Dispose();
+            }
+            runningTasks.Clear();
+        }
+    }
+}

--- a/Assets/GeoTileLoader/Scripts/TaskScheduler.cs.meta
+++ b/Assets/GeoTileLoader/Scripts/TaskScheduler.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8aa5e3f626e1e4280ba27845630c1ceb
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -223,7 +223,7 @@ namespace GeoTile
                     });
                     try
                     {
-                        await loader.ReadJson(this, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
+                        await loader.ReadJsonAsync(this, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
                         Debug.Log($"ReadJson at {trans.name} success.");
                     }
                     catch (Exception e)

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -64,6 +64,7 @@ namespace GeoTile
         private void Start()
         {
             CreateModelLoadScheduler();
+            CreateJsonLoadScheduler();
             StartCoroutine(LoopCollectCopyright());
         }
 
@@ -113,7 +114,7 @@ namespace GeoTile
         /// <summary>
         /// ModelLoadScheduler用タスク
         /// </summary>
-        public class ModelLoadTask : ModelLoadScheduler.Task
+        public class ModelLoadTask : GeoTile.TaskScheduler.Task
         {
             TileSetNodeComponent node;
 
@@ -171,83 +172,21 @@ namespace GeoTile
         /// <returns></returns>
         public async UniTask LoadSubTrees(int maxLevels, int maxNodes, CancellationToken token)
         {
-            await LoadSubTreesRecursive(transform, maxLevels, maxNodes, token);
+            // 最初のタスクを追加
+            JsonLoadScheduler.Instance.AddLoadSubTreeTask(
+                "RootSubTree",
+                this,
+                transform,
+                maxLevels,
+                maxNodes,
+                token,
+                0
+            );
+
+            // すべてのタスクが完了するまで待つ
+            await UniTask.WaitWhile(() => JsonLoadScheduler.Instance.RemainingTasksCount > 0, cancellationToken: token);
         }
 
-        /// <summary>
-        /// 再帰的にサブツリーをロードする
-        /// return maxNodes
-        /// </summary>
-        /// <param name="trans"></param>
-        /// <param name="maxLevels"></param>
-        /// <param name="maxNodes"></param>
-        /// <param name="token"></param>
-        /// <returns></returns>
-        private async UniTask<int> LoadSubTreesRecursive(Transform trans, int maxLevels, int maxNodes, CancellationToken token)
-        {
-            maxNodes--;
-            if (maxNodes <= 0)
-            {
-                Debug.LogWarning("maxNodes reached.");
-                return maxNodes;
-            }
-
-            {
-                // サブツリーが存在して、既にロードされていなければロードする
-                var node = trans.GetComponent<TileSetNodeComponent>();
-                if (node != null
-                    && node.gameObject.activeInHierarchy
-                    && node.SubTreeExists()
-                    && !node.SubTreeAlreadyLoaded())
-                {
-                    var contentUrl = node.TileSetNode?.content?.Url;
-                    var newUri = new Uri(new Uri(node.BaseJsonUrl), contentUrl);
-                    var query = node.TileSetNode?.content?.contentUrlQuery;
-                    Debug.Log("content query:" + query);
-                    var sessionId = node.GoogleSessionId;
-                    var sessionKeyValue = query.Split("&").Select(v => v.Split("=")).Where(kv => kv[0] == "session")
-                        .ToList();
-                    if (sessionKeyValue.Count > 0)
-                    {
-                        sessionId = sessionKeyValue[0][1];
-                    }
-
-                    var loader = new TileSetHierarchyLoader(new TileSetHierarchyLoaderConfig()
-                    {
-                        TileSetJsonUrl = newUri.ToString(),
-                        TileSetName = "",
-                        GoogleSessionId = sessionId,
-                        GoogleMapTileApiKey = node.TileSetInfoProvider.LoaderConfig.GoogleMapTileApiKey,
-                        CullingInfo = node.CullingInfo,
-                        RootParent = node.TileSetInfoProvider.LoaderConfig.RootParent,
-                    });
-                    try
-                    {
-                        await loader.ReadJsonAsync(this, node.transform, node.TileSetInfoProvider.LoaderConfig.CullingInfo.cullCollider, token);
-                        Debug.Log($"ReadJson at {trans.name} success.");
-                    }
-                    catch (Exception e)
-                    {
-                        Debug.LogError($"ReadJson at {trans.name} failed. e: " + e);
-                    }
-                }
-            }
-
-            foreach (Transform child in trans)
-            {
-                var node = child.GetComponent<TileSetNodeComponent>();
-                if (node != null && node.gameObject.activeInHierarchy)
-                {
-                    maxNodes = await LoadSubTreesRecursive(child, maxLevels - 1, maxNodes, token);
-                    if (maxNodes <= 0)
-                    {
-                        break;
-                    }
-                }
-            }
-
-            return maxNodes;
-        }
 
         /// <summary>
         /// ヒエラルキー内に存在するタイルの著作権表示を収集し、CopyrightAttributionText に保存する。
@@ -273,6 +212,14 @@ namespace GeoTile
             if (ModelLoadScheduler.Instance == null)
             {
                 ModelLoadScheduler.CreateGameObject();
+            }
+        }
+
+        private void CreateJsonLoadScheduler()
+        {
+            if (JsonLoadScheduler.Instance == null)
+            {
+                JsonLoadScheduler.CreateGameObject();
             }
         }
     }

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -50,6 +50,42 @@ namespace GeoTile
         public TileSetHierarchyLoaderConfig LoaderConfig { get; set; }
 
         /// <summary>
+        /// ノード数制限とカウンター情報
+        /// </summary>
+        public int MaxNodeCount { get; private set; } = 10000; // デフォルト値
+        public int CurrentNodeCount { get; private set; } = 0;
+
+        /// <summary>
+        /// MaxNodeCountを設定
+        /// </summary>
+        public void SetMaxNodeCount(int maxNodes)
+        {
+            MaxNodeCount = maxNodes;
+        }
+
+        /// <summary>
+        /// ノードカウントを増加させる
+        /// </summary>
+        /// <returns>増加後のカウント。maxNodesを超えた場合は-1を返す</returns>
+        public int IncrementNodeCount()
+        {
+            if (CurrentNodeCount >= MaxNodeCount)
+            {
+                return -1; // 制限に達している
+            }
+            CurrentNodeCount++;
+            return CurrentNodeCount;
+        }
+
+        /// <summary>
+        /// ノードカウントをリセット
+        /// </summary>
+        public void ResetNodeCount()
+        {
+            CurrentNodeCount = 0;
+        }
+
+        /// <summary>
         /// 著作権表示文字列
         /// </summary>
         public string CopyrightAttributionText { get; private set; }
@@ -172,13 +208,16 @@ namespace GeoTile
         /// <returns></returns>
         public async UniTask LoadSubTrees(int maxLevels, int maxNodes, CancellationToken token)
         {
+            // ノードカウンターをリセットしてmaxNodesを設定
+            ResetNodeCount();
+            SetMaxNodeCount(maxNodes);
+            
             // 最初のタスクを追加
             JsonLoadScheduler.Instance.AddLoadSubTreeTask(
                 "RootSubTree",
                 this,
                 transform,
                 maxLevels,
-                maxNodes,
                 token,
                 0
             );

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchyLoader.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchyLoader.cs
@@ -56,14 +56,15 @@ namespace GeoTile
 
         // Start is called before the first frame update
         /// <summary>
-        /// 3DTileSetのjsonをロードする
+        /// 3DTileSetのjsonをロードする(1つのjson内のサブツリーを読み込む)
+        /// カリングも行う
         /// </summary>
         /// <param name="rootHierarchy">サブツリー読み込み時は、タイルセット全体のルートにあるTileSetHierarchyをわたす。メインツリー読み込み時はnullを指定</param>
         /// <param name="parentTrans">サブツリーを読み込む場合の親Transform</param>
         /// <param name="onResult"></param>
         /// <param name="token"></param>
         /// <returns>生成されたルートGameObject (rootHierarchy == nullの場合), rootHierarchy != null の場合は parentTrans引数の値を返す。エラーの場合はnullを返す</returns>
-        public async UniTask<Transform> ReadJson(TileSetHierarchy rootHierarchy, Transform parentTrans, Collider cullCollider, CancellationToken token)
+        public async UniTask<Transform> ReadJsonAsync(TileSetHierarchy rootHierarchy, Transform parentTrans, Collider cullCollider, CancellationToken token)
         {
             Transform trans = null;
             TileSetHierarchy hierarchy = rootHierarchy;
@@ -111,7 +112,7 @@ namespace GeoTile
                 }
             }
 
-            await ReadJsonFromUrlCoroutine(trans, url, hierarchy, token);
+            await ReadJsonFromUrlAsync(trans, url, hierarchy, token);
             Debug.Log("ReadJsonFromUrlCoroutine finished!");
             List<Transform> children = trans
                            .Cast<Transform>()
@@ -136,7 +137,7 @@ namespace GeoTile
             return trans;
         }
 
-        async UniTask ReadJsonFromUrlCoroutine(Transform parent, string url, TileSetHierarchy hierarchy, CancellationToken token)
+        async UniTask ReadJsonFromUrlAsync(Transform parent, string url, TileSetHierarchy hierarchy, CancellationToken token)
         {
             Debug.Log("loading: " + url);
             using (var req = new UnityWebRequest(url))

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchyLoader.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchyLoader.cs
@@ -144,6 +144,7 @@ namespace GeoTile
             using (var buf = new DownloadHandlerBuffer())
             {
                 req.downloadHandler = buf;
+                req.timeout = 10; // timeout seconds
                 await req.SendWebRequest().WithCancellation(token);
                 if (req.result != UnityWebRequest.Result.Success)
                 {


### PR DESCRIPTION
fixes #32 

## 概要

どうやら6/13前後に、GoogleのAPIの変更があり、Photorealistic 3D Tiles API の返すツリーが含む（ツリーノード情報json部分の）URLロードの量が増えたようだ。もしかすると末端のノードが単独URLになったのかもしれない。
範囲200mで300URL以上になっていて、ロードが遅い。
今まで直列的ロードを行っていたが、300URLを平均0.1秒で読むとロード時間30秒となってしまう。
このため並列化を行う。
