### PR TITLE
load meshes from center (google 3d tiles)

### DIFF
--- a/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
+++ b/Assets/GeoTileLoader/Scripts/GltfInstantiatorWithGltFast.cs
@@ -26,6 +26,7 @@ namespace GeoTile
             {
                 if (center != null)
                 {
+                    // google 3D Tiles uses this course (2025/6/15)
                     pos = new Vector3(
                         (float)(center[0] + modelOffset.x),
                         (float)(center[1] + modelOffset.y),
@@ -34,6 +35,7 @@ namespace GeoTile
                 }
                 else
                 {
+                    // I don't know the correctness  (2025/6/15)
                     pos = new Vector3(
                         (float)(- component.GlobalBasePos[0] + modelOffset.x),
                         (float)(- component.GlobalBasePos[1] + modelOffset.y),

--- a/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
+++ b/Assets/GeoTileLoader/Scripts/TaskScheduler.cs
@@ -110,12 +110,26 @@ namespace GeoTile
 
         /// <summary>
         /// Add a task to the execution queue
+        /// Tasks are inserted in priority order (highest priority first)
         /// </summary>
         public TaskCarrier AddTask(string name, CancellationToken token, float priority, Task task)
         {
             var carrier = new TaskCarrier(name, token, task);
             carrier.Priority = priority;
-            waitingTasks.Add(carrier);
+            
+            // 優先度順に挿入位置を決定（高い優先度が先頭に来るように）
+            int insertIndex = 0;
+            for (int i = 0; i < waitingTasks.Count; i++)
+            {
+                if (priority > waitingTasks[i].Priority)
+                {
+                    insertIndex = i;
+                    break;
+                }
+                insertIndex = i + 1;
+            }
+            
+            waitingTasks.Insert(insertIndex, carrier);
             return carrier;
         }
 

--- a/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
+++ b/Assets/GeoTileLoader/Scripts/TileSetHierarchy.cs
@@ -196,9 +196,38 @@ namespace GeoTile
 
             // ModelLoadScheduler にタスクを登録して終了！
 
-            // ユーザーがみている場所に近いタイルのpriorityをあげたりしたい。
-            float priority = 0;
+            // 中心からの距離に基づいて優先度を計算
+            float priority = CalculateNodePriority(node);
             ModelLoadScheduler.Instance.AddTask(node.name, token, priority, new ModelLoadTask(node));
+        }
+
+        /// <summary>
+        /// ノードの優先度を計算する（中心からの距離に基づく）
+        /// 距離が近いほど高い優先度（大きな値）を返す
+        /// </summary>
+        /// <param name="node">対象ノード</param>
+        /// <returns>優先度（距離が近いほど大きな値）</returns>
+        private float CalculateNodePriority(TileSetNodeComponent node)
+        {
+            if (node.NodeBasePos == null || node.NodeBasePos.Length < 3)
+            {
+                return 0.0f; // NodeBasePosが無効な場合は最低優先度
+            }
+
+            // NodeBasePosをVectorD3に変換（ECEF座標）
+            var nodePosition = new VectorD3(node.NodeBasePos[0], node.NodeBasePos[1], node.NodeBasePos[2]);
+            
+            // 中心座標との距離を計算
+            var centerPosition = ModelCenterEcefCoordinate;
+            var distance = (nodePosition - centerPosition).magnitude;
+            
+            // 距離に基づく優先度を計算（近いほど高い優先度）
+            // 最大距離を100kmと仮定して正規化
+            const double maxDistance = 100000.0; // 100km in meters
+            var normalizedDistance = Math.Min(distance / maxDistance, 1.0);
+            
+            // 1.0から正規化距離を引いて、近いほど高い値になるようにする
+            return (float)(1.0 - normalizedDistance);
         }
 
         /// <summary>


### PR DESCRIPTION
## 概要

今までロード順序はノードツリーのトラバース順になっていたが、ロード対象中心付近からロードするようにする。
ECEF座標での距離順にpriorityをつけて、priority順にソートされたwaitingTasksからタスクを取り出す。
Google 3D Tilesのみで検証済み。

Fixes #27 
